### PR TITLE
Fixes Issue #14 - added one tachyons css class to center subtitle text

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
     <main>
         <section class="content content--layout">
             <h2 class="word word--moveout">Recidiviz</h2>
-            <h4 class="f3 content-center: center">a platform for tracking granular recidivism metrics in real time</h4>
+            <h4 class="f3 tc content-center: center">a platform for tracking granular recidivism metrics in real time</h4>
             <div class="flex items-center justify-center pa4 mt6 bg-alert-blue text-our-gray">
                 <svg class="w1" data-icon="info" viewBox="0 0 32 32" style="fill:currentcolor">
                     <title>info icon</title>


### PR DESCRIPTION
Just one CSS class to preserve center alignment on mobile. Photo attached 

<img width="539" alt="screen shot 2018-04-22 at 6 25 39 pm" src="https://user-images.githubusercontent.com/4020102/39097914-d7d10b02-465a-11e8-92e4-8f33d62dc658.png">
