### PR TITLE
Use Formspree to make contact form secure, resolves #32

### DIFF
--- a/index.html
+++ b/index.html
@@ -189,7 +189,7 @@
 							<p>Whether you're looking to collaborate, inquire about our work, or just ask questions, we'd love to hear from you.</p>
 							<div class="split style1">
 								<section>
-									<form method="post" action="mailto:team@recidiviz.com?subject=Connect">
+									<form method="post" action="https://formspree.io/team@recidiviz.com">
 										<div class="field half first">
 											<label for="name">Name</label>
 											<input type="text" name="name" id="name" />
@@ -201,6 +201,9 @@
 										<div class="field">
 											<label for="message">Message</label>
 											<textarea name="message" id="message" rows="5"></textarea>
+										</div>
+										<div>
+											<input type="text" name="_gotcha" style="display:none" />
 										</div>
 										<ul class="actions">
 											<li><a href="" class="button submit">Send Message</a></li>


### PR DESCRIPTION
Resolves #32.

The `_gotcha` field is to prevent spammers that use scrapers. When that field is populated, a submission is silently ignored.

Note: after this gets deployed, someone with access to team@recidiviz.com will need to go submit the form the first time and verify the email. Additional submissions will not work until this has been completed.