### PR TITLE
'Reach out to learn more' buttons scroll to contact form instead of using mailto links

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
 									<h2>Project Pulse</h2>
 									<p>Automatically collect, standardize, and centralize corrections data to create a rigorous baseline. Calculate granular metrics on an ongoing basis.</p>
 									<ul class="actions">
-										<li><a href="mailto:team@recidiviz.com?subject=Project%20Pulse" class="button">Reach out to learn more</a></li>
+										<li><a href="#connect" class="button scrolly">Reach out to learn more</a></li>
 									</ul>
 								</div>
 							</div>
@@ -93,7 +93,7 @@
 									<h2>Project Vitals</h2>
 									<p>Make data and metrics from Project Pulse available to decision-makers and stakeholders in actionable formats. Tailor reports to key decision criteria to help states and jurisdictions predict whether they will meet their year-end goals.</p>
 									<ul class="actions">
-										<li><a href="mailto:team@recidiviz.com?subject=Project%20Vitals" class="button">Reach out to learn more</a></li>
+										<li><a href="#connect" class="button scrolly">Reach out to learn more</a></li>
 									</ul>
 								</div>
 							</div>
@@ -105,7 +105,7 @@
 									<h2>Project Triage</h2>
 									<p>Enable decision makers to add external datasets on in-prison programming (education, work opportunities), post-release programming, or other factors to Project Pulse data to form a more complete picture. Serve as a mechanism for independently verifying which programs are driving desired outcomes.</p>
 									<ul class="actions">
-										<li><a href="mailto:team@recidiviz.com?subject=Project%20Triage" class="button">Reach out to learn more</a></li>
+										<li><a href="#connect" class="button scrolly">Reach out to learn more</a></li>
 									</ul>
 								</div>
 							</div>


### PR DESCRIPTION
One thing I considered doing here was also adding some JS to update the contact form to include which project the user clicked on. That isn't much effort, probably only another 30 or so minutes of work, but I decided to apply YAGNI until it proved worth even that small amount of time. If we get several emails where people don't highlight what they're interested in, we can come back and add this.